### PR TITLE
Add transfer member function to VectorStorage

### DIFF
--- a/src/utils/VectorStorage.h
+++ b/src/utils/VectorStorage.h
@@ -204,6 +204,36 @@ namespace dftefe
       void
       transfer(
         VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const;
+      
+      /**
+       * @brief Copies the data to a VectorStorage object in a different memory space.
+       * This provides a seamless interface to copy back and forth between
+       * memory spaces , including between the same memory spaces. This is a more
+       * granular version of the above transfer function as it provides transfer
+       * from a specific portion of the source VectorStorage to a specific
+       * portion of the destination VectorStorage.
+       *
+       * @note The destination VectorStorage must be pre-allocated appropriately
+       *
+       * @tparam memorySpaceDst memory space of the destination VectorStorage
+       * @param[in] dstVectorStorage reference to the destination
+       *  VectorStorage. It must be pre-allocated appropriately
+       * @param[in] N number of entries of the source VectorStorage 
+       *  that needs to be copied to the destination VectorStorage
+       * @param[in] srcOffset offset relative to the start of the source 
+       *  VectorStorage from which we need to copy data
+       * @param[in] dstOffset offset relative to the start of the destination 
+       *  VectorStorage to which we need to copy data
+       * @param[out] dstVectorStorage reference to the destination
+       *  VectorStorage with the data copied into it
+       */
+      template <dftefe::utils::MemorySpace memorySpaceDst>
+      void
+      transfer(
+        VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
+	const size_type N,
+	const size_type srcOffset,
+	const size_type dstOffset) const;
 
     private:
       ValueType *d_data = nullptr;

--- a/src/utils/VectorStorage.h
+++ b/src/utils/VectorStorage.h
@@ -36,6 +36,17 @@ namespace dftefe
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
     class VectorStorage
     {
+      /**
+       * @brief A class template to provide an interface that can act similar to
+       * STL vectors but with different MemorySpace---
+       * HOST (cpu) , DEVICE (gpu), etc,.
+       *
+       * @tparam ValueType The underlying value type for the VectorStorage
+       *  (e.g., int, double, complex<double>, etc.)
+       * @tparam memorySpace The memory space in which the VectorStorage needs
+       *  to reside
+       *
+       */
       typedef ValueType        value_type;
       typedef ValueType *      pointer;
       typedef ValueType &      reference;
@@ -47,8 +58,8 @@ namespace dftefe
       VectorStorage() = default;
 
       /**
-       * @brief Copy constructor for a Vector
-       * @param[in] u Vector object to copy from
+       * @brief Copy constructor for a VectorStorage
+       * @param[in] u VectorStorage object to copy from
        */
       VectorStorage(const VectorStorage &u);
 
@@ -175,6 +186,24 @@ namespace dftefe
        */
       const ValueType *
       data() const noexcept;
+
+      /**
+       * @brief Copies the data to a VectorStorage object in a different memory space.
+       * This provides a seamless interface to copy back and forth between
+       * memory spaces , including between the same memory spaces.
+       *
+       * @note The destination VectorStorage must be pre-allocated appropriately
+       *
+       * @tparam memorySpaceDst memory space of the destination VectorStorage
+       * @param[in] dstVectorStorage reference to the destination
+       *  VectorStorage. It must be pre-allocated appropriately
+       * @param[out] dstVectorStorage reference to the destination
+       *  VectorStorage with the data copied into it
+       */
+      template <dftefe::utils::MemorySpace memorySpaceDst>
+      void
+      transfer(
+        VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const;
 
     private:
       ValueType *d_data = nullptr;

--- a/src/utils/VectorStorage.h
+++ b/src/utils/VectorStorage.h
@@ -202,38 +202,37 @@ namespace dftefe
        */
       template <dftefe::utils::MemorySpace memorySpaceDst>
       void
-      transfer(
+      transferTo(
         VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const;
-      
+
       /**
        * @brief Copies the data to a VectorStorage object in a different memory space.
        * This provides a seamless interface to copy back and forth between
-       * memory spaces , including between the same memory spaces. This is a more
-       * granular version of the above transfer function as it provides transfer
-       * from a specific portion of the source VectorStorage to a specific
-       * portion of the destination VectorStorage.
+       * memory spaces , including between the same memory spaces. This is a
+       * more granular version of the above transfer function as it provides
+       * transfer from a specific portion of the source VectorStorage to a
+       * specific portion of the destination VectorStorage.
        *
        * @note The destination VectorStorage must be pre-allocated appropriately
        *
        * @tparam memorySpaceDst memory space of the destination VectorStorage
        * @param[in] dstVectorStorage reference to the destination
        *  VectorStorage. It must be pre-allocated appropriately
-       * @param[in] N number of entries of the source VectorStorage 
+       * @param[in] N number of entries of the source VectorStorage
        *  that needs to be copied to the destination VectorStorage
-       * @param[in] srcOffset offset relative to the start of the source 
+       * @param[in] srcOffset offset relative to the start of the source
        *  VectorStorage from which we need to copy data
-       * @param[in] dstOffset offset relative to the start of the destination 
+       * @param[in] dstOffset offset relative to the start of the destination
        *  VectorStorage to which we need to copy data
        * @param[out] dstVectorStorage reference to the destination
        *  VectorStorage with the data copied into it
        */
       template <dftefe::utils::MemorySpace memorySpaceDst>
       void
-      transfer(
-        VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
-	const size_type N,
-	const size_type srcOffset,
-	const size_type dstOffset) const;
+      transferTo(VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
+                 const size_type                           N,
+                 const size_type                           srcOffset,
+                 const size_type                           dstOffset) const;
 
     private:
       ValueType *d_data = nullptr;

--- a/src/utils/VectorStorage.h
+++ b/src/utils/VectorStorage.h
@@ -202,14 +202,13 @@ namespace dftefe
        */
       template <dftefe::utils::MemorySpace memorySpaceDst>
       void
-      transferTo(
-        VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const;
+      copyTo(VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const;
 
       /**
        * @brief Copies the data to a VectorStorage object in a different memory space.
        * This provides a seamless interface to copy back and forth between
        * memory spaces , including between the same memory spaces. This is a
-       * more granular version of the above transfer function as it provides
+       * more granular version of the above copyTo function as it provides
        * transfer from a specific portion of the source VectorStorage to a
        * specific portion of the destination VectorStorage.
        *
@@ -229,10 +228,55 @@ namespace dftefe
        */
       template <dftefe::utils::MemorySpace memorySpaceDst>
       void
-      transferTo(VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
-                 const size_type                           N,
-                 const size_type                           srcOffset,
-                 const size_type                           dstOffset) const;
+      copyTo(VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
+             const size_type                           N,
+             const size_type                           srcOffset,
+             const size_type                           dstOffset) const;
+
+      /**
+       * @brief Copies data from a VectorStorage object in a different memory space.
+       * This provides a seamless interface to copy back and forth between
+       * memory spaces, including between the same memory spaces.
+       *
+       * @note The VectorStorage must be pre-allocated appropriately
+       *
+       * @tparam memorySpaceSrc memory space of the source VectorStorage
+       *  from which to copy
+       * @param[in] srcVectorStorage reference to the source
+       *  VectorStorage
+       */
+      template <dftefe::utils::MemorySpace memorySpaceSrc>
+      void
+      copyFrom(
+        const VectorStorage<ValueType, memorySpaceSrc> &srcVectorStorage);
+
+      /**
+       * @brief Copies data from a VectorStorage object in a different memory space.
+       * This provides a seamless interface to copy back and forth between
+       * memory spaces, including between the same memory spaces.
+       * This is a more granular version of the above copyFrom function as it
+       * provides transfer from a specific portion of the source VectorStorage
+       * to a specific portion of the destination VectorStorage.
+       *
+       * @note The VectorStorage must be pre-allocated appropriately
+       *
+       * @tparam memorySpaceSrc memory space of the source VectorStorage
+       *  from which to copy
+       * @param[in] srcVectorStorage reference to the source
+       *  VectorStorage
+       * @param[in] N number of entries of the source VectorStorage
+       *  that needs to be copied to the destination VectorStorage
+       * @param[in] srcOffset offset relative to the start of the source
+       *  VectorStorage from which we need to copy data
+       * @param[in] dstOffset offset relative to the start of the destination
+       *  VectorStorage to which we need to copy data
+       */
+      template <dftefe::utils::MemorySpace memorySpaceSrc>
+      void
+      copyFrom(VectorStorage<ValueType, memorySpaceSrc> &srcVectorStorage,
+               const size_type                           N,
+               const size_type                           srcOffset,
+               const size_type                           dstOffset);
 
     private:
       ValueType *d_data = nullptr;

--- a/src/utils/VectorStorage.t.cpp
+++ b/src/utils/VectorStorage.t.cpp
@@ -255,7 +255,7 @@ namespace dftefe
       VectorStorage<ValueType, memorySpaceSrc> &srcVectorStorage,
       const size_type                           N,
       const size_type                           srcOffset,
-      const size_type                           dstOffset) 
+      const size_type                           dstOffset)
     {
       throwException<DomainError>(
         srcOffset + N <= srcVectorStorage.size(),

--- a/src/utils/VectorStorage.t.cpp
+++ b/src/utils/VectorStorage.t.cpp
@@ -208,6 +208,31 @@ namespace dftefe
       MemoryTransfer<memorySpaceDst, memorySpace> memoryTransfer;
       memoryTransfer.copy(d_size, dstVectorStorage.begin(), d_data);
     }
+      
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    template <dftefe::utils::MemorySpace memorySpaceDst>
+      void
+      VectorStorage<ValueType, memorySpace>::transfer(
+        VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
+	const size_type N,
+	const size_type srcOffset,
+	const size_type dstOffset) const
+      {
+
+	throwException<DomainError>(srcOffset + N <= d_size, 
+	    "The offset and copy size specified for the source VectorStorage"
+	    " is out of range for it.");
+
+	throwException<DomainError>(
+	    dstOffset + N <= dstVectorStorage.size(), 
+	    "The offset and size specified for the destination VectorStorage"
+	    " is out of range for it.");
+      
+	MemoryTransfer<memorySpaceDst, memorySpace> memoryTransfer;
+        memoryTransfer.copy(N, dstVectorStorage.begin() + dstOffset, 
+	  this->begin()+srcOffset);
+
+      }
 
 
 

--- a/src/utils/VectorStorage.t.cpp
+++ b/src/utils/VectorStorage.t.cpp
@@ -199,20 +199,20 @@ namespace dftefe
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
     template <dftefe::utils::MemorySpace memorySpaceDst>
     void
-    VectorStorage<ValueType, memorySpace>::transferTo(
+    VectorStorage<ValueType, memorySpace>::copyTo(
       VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const
     {
       throwException<DomainError>(
         d_size == dstVectorStorage.size(),
         "The source and destination VectorStorage are of different sizes");
       MemoryTransfer<memorySpaceDst, memorySpace> memoryTransfer;
-      memoryTransfer.copy(d_size, dstVectorStorage.begin(), d_data);
+      memoryTransfer.copy(d_size, dstVectorStorage.begin(), this->begin());
     }
 
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
     template <dftefe::utils::MemorySpace memorySpaceDst>
     void
-    VectorStorage<ValueType, memorySpace>::transferTo(
+    VectorStorage<ValueType, memorySpace>::copyTo(
       VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
       const size_type                           N,
       const size_type                           srcOffset,
@@ -235,6 +235,43 @@ namespace dftefe
     }
 
 
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    template <dftefe::utils::MemorySpace memorySpaceSrc>
+    void
+    VectorStorage<ValueType, memorySpace>::copyFrom(
+      const VectorStorage<ValueType, memorySpaceSrc> &srcVectorStorage)
+    {
+      throwException<DomainError>(
+        d_size == srcVectorStorage.size(),
+        "The source and destination VectorStorage are of different sizes");
+      MemoryTransfer<memorySpace, memorySpaceSrc> memoryTransfer;
+      memoryTransfer.copy(d_size, this->begin(), srcVectorStorage.begin());
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    template <dftefe::utils::MemorySpace memorySpaceSrc>
+    void
+    VectorStorage<ValueType, memorySpace>::copyFrom(
+      VectorStorage<ValueType, memorySpaceSrc> &srcVectorStorage,
+      const size_type                           N,
+      const size_type                           srcOffset,
+      const size_type                           dstOffset) 
+    {
+      throwException<DomainError>(
+        srcOffset + N <= srcVectorStorage.size(),
+        "The offset and copy size specified for the source VectorStorage"
+        " is out of range for it.");
+
+      throwException<DomainError>(
+        dstOffset + N <= d_size,
+        "The offset and size specified for the destination VectorStorage"
+        " is out of range for it.");
+
+      MemoryTransfer<memorySpace, memorySpaceSrc> memoryTransfer;
+      memoryTransfer.copy(N,
+                          this->begin() + dstOffset,
+                          srcVectorStorage.begin() + srcOffset);
+    }
 
   } // namespace utils
 } // namespace dftefe

--- a/src/utils/VectorStorage.t.cpp
+++ b/src/utils/VectorStorage.t.cpp
@@ -196,5 +196,20 @@ namespace dftefe
       return d_data;
     }
 
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    template <dftefe::utils::MemorySpace memorySpaceDst>
+    void
+    VectorStorage<ValueType, memorySpace>::transfer(
+      VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const
+    {
+      throwException<DomainError>(
+        d_size == dstVectorStorage.size(),
+        "The source and destination VectorStorage are of different sizes");
+      MemoryTransfer<memorySpaceDst, memorySpace> memoryTransfer;
+      memoryTransfer.copy(d_size, dstVectorStorage.begin(), d_data);
+    }
+
+
+
   } // namespace utils
 } // namespace dftefe

--- a/src/utils/VectorStorage.t.cpp
+++ b/src/utils/VectorStorage.t.cpp
@@ -199,7 +199,7 @@ namespace dftefe
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
     template <dftefe::utils::MemorySpace memorySpaceDst>
     void
-    VectorStorage<ValueType, memorySpace>::transfer(
+    VectorStorage<ValueType, memorySpace>::transferTo(
       VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const
     {
       throwException<DomainError>(
@@ -208,31 +208,31 @@ namespace dftefe
       MemoryTransfer<memorySpaceDst, memorySpace> memoryTransfer;
       memoryTransfer.copy(d_size, dstVectorStorage.begin(), d_data);
     }
-      
+
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
     template <dftefe::utils::MemorySpace memorySpaceDst>
-      void
-      VectorStorage<ValueType, memorySpace>::transfer(
-        VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
-	const size_type N,
-	const size_type srcOffset,
-	const size_type dstOffset) const
-      {
+    void
+    VectorStorage<ValueType, memorySpace>::transferTo(
+      VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
+      const size_type                           N,
+      const size_type                           srcOffset,
+      const size_type                           dstOffset) const
+    {
+      throwException<DomainError>(
+        srcOffset + N <= d_size,
+        "The offset and copy size specified for the source VectorStorage"
+        " is out of range for it.");
 
-	throwException<DomainError>(srcOffset + N <= d_size, 
-	    "The offset and copy size specified for the source VectorStorage"
-	    " is out of range for it.");
+      throwException<DomainError>(
+        dstOffset + N <= dstVectorStorage.size(),
+        "The offset and size specified for the destination VectorStorage"
+        " is out of range for it.");
 
-	throwException<DomainError>(
-	    dstOffset + N <= dstVectorStorage.size(), 
-	    "The offset and size specified for the destination VectorStorage"
-	    " is out of range for it.");
-      
-	MemoryTransfer<memorySpaceDst, memorySpace> memoryTransfer;
-        memoryTransfer.copy(N, dstVectorStorage.begin() + dstOffset, 
-	  this->begin()+srcOffset);
-
-      }
+      MemoryTransfer<memorySpaceDst, memorySpace> memoryTransfer;
+      memoryTransfer.copy(N,
+                          dstVectorStorage.begin() + dstOffset,
+                          this->begin() + srcOffset);
+    }
 
 
 

--- a/src/utils/VectorStorage.t.cpp
+++ b/src/utils/VectorStorage.t.cpp
@@ -205,8 +205,8 @@ namespace dftefe
       throwException<DomainError>(
         d_size == dstVectorStorage.size(),
         "The source and destination VectorStorage are of different sizes");
-      MemoryTransfer<memorySpaceDst, memorySpace> memoryTransfer;
-      memoryTransfer.copy(d_size, dstVectorStorage.begin(), this->begin());
+      MemoryTransfer<memorySpaceDst, memorySpace>::copy(
+        d_size, dstVectorStorage.begin(), this->begin());
     }
 
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
@@ -228,10 +228,8 @@ namespace dftefe
         "The offset and size specified for the destination VectorStorage"
         " is out of range for it.");
 
-      MemoryTransfer<memorySpaceDst, memorySpace> memoryTransfer;
-      memoryTransfer.copy(N,
-                          dstVectorStorage.begin() + dstOffset,
-                          this->begin() + srcOffset);
+      MemoryTransfer<memorySpaceDst, memorySpace>::copy(
+        N, dstVectorStorage.begin() + dstOffset, this->begin() + srcOffset);
     }
 
 
@@ -244,8 +242,8 @@ namespace dftefe
       throwException<DomainError>(
         d_size == srcVectorStorage.size(),
         "The source and destination VectorStorage are of different sizes");
-      MemoryTransfer<memorySpace, memorySpaceSrc> memoryTransfer;
-      memoryTransfer.copy(d_size, this->begin(), srcVectorStorage.begin());
+      MemoryTransfer<memorySpace, memorySpaceSrc>::copy(
+        d_size, this->begin(), srcVectorStorage.begin());
     }
 
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
@@ -267,10 +265,8 @@ namespace dftefe
         "The offset and size specified for the destination VectorStorage"
         " is out of range for it.");
 
-      MemoryTransfer<memorySpace, memorySpaceSrc> memoryTransfer;
-      memoryTransfer.copy(N,
-                          this->begin() + dstOffset,
-                          srcVectorStorage.begin() + srcOffset);
+      MemoryTransfer<memorySpace, memorySpaceSrc>::copy(
+        N, this->begin() + dstOffset, srcVectorStorage.begin() + srcOffset);
     }
 
   } // namespace utils


### PR DESCRIPTION
Added transfer member function in utils::VectorStorage which provides an interface to data transfer across memory spaces.