### PR TITLE
Vector transfer

### DIFF
--- a/src/utils/VectorStorage.h
+++ b/src/utils/VectorStorage.h
@@ -36,6 +36,17 @@ namespace dftefe
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
     class VectorStorage
     {
+      /**
+       * @brief A class template to provide an interface that can act similar to
+       * STL vectors but with different MemorySpace---
+       * HOST (cpu) , DEVICE (gpu), etc,.
+       *
+       * @tparam ValueType The underlying value type for the VectorStorage
+       *  (e.g., int, double, complex<double>, etc.)
+       * @tparam memorySpace The memory space in which the VectorStorage needs
+       *  to reside
+       *
+       */
       typedef ValueType        value_type;
       typedef ValueType *      pointer;
       typedef ValueType &      reference;
@@ -47,8 +58,8 @@ namespace dftefe
       VectorStorage() = default;
 
       /**
-       * @brief Copy constructor for a Vector
-       * @param[in] u Vector object to copy from
+       * @brief Copy constructor for a VectorStorage
+       * @param[in] u VectorStorage object to copy from
        */
       VectorStorage(const VectorStorage &u);
 
@@ -153,7 +164,7 @@ namespace dftefe
        * @param[in] initVal initial value of elements of the Vector
        */
       void
-      resize(size_type size, ValueType initVal = 0);
+      resize(size_type size, ValueType initVal = ValueType());
 
       /**
        * @brief Returns the dimension of the Vector
@@ -175,6 +186,97 @@ namespace dftefe
        */
       const ValueType *
       data() const noexcept;
+
+      /**
+       * @brief Copies the data to a VectorStorage object in a different memory space.
+       * This provides a seamless interface to copy back and forth between
+       * memory spaces , including between the same memory spaces.
+       *
+       * @note The destination VectorStorage must be pre-allocated appropriately
+       *
+       * @tparam memorySpaceDst memory space of the destination VectorStorage
+       * @param[in] dstVectorStorage reference to the destination
+       *  VectorStorage. It must be pre-allocated appropriately
+       * @param[out] dstVectorStorage reference to the destination
+       *  VectorStorage with the data copied into it
+       */
+      template <dftefe::utils::MemorySpace memorySpaceDst>
+      void
+      copyTo(VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const;
+
+      /**
+       * @brief Copies the data to a VectorStorage object in a different memory space.
+       * This provides a seamless interface to copy back and forth between
+       * memory spaces , including between the same memory spaces. This is a
+       * more granular version of the above copyTo function as it provides
+       * transfer from a specific portion of the source VectorStorage to a
+       * specific portion of the destination VectorStorage.
+       *
+       * @note The destination VectorStorage must be pre-allocated appropriately
+       *
+       * @tparam memorySpaceDst memory space of the destination VectorStorage
+       * @param[in] dstVectorStorage reference to the destination
+       *  VectorStorage. It must be pre-allocated appropriately
+       * @param[in] N number of entries of the source VectorStorage
+       *  that needs to be copied to the destination VectorStorage
+       * @param[in] srcOffset offset relative to the start of the source
+       *  VectorStorage from which we need to copy data
+       * @param[in] dstOffset offset relative to the start of the destination
+       *  VectorStorage to which we need to copy data
+       * @param[out] dstVectorStorage reference to the destination
+       *  VectorStorage with the data copied into it
+       */
+      template <dftefe::utils::MemorySpace memorySpaceDst>
+      void
+      copyTo(VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
+             const size_type                           N,
+             const size_type                           srcOffset,
+             const size_type                           dstOffset) const;
+
+      /**
+       * @brief Copies data from a VectorStorage object in a different memory space.
+       * This provides a seamless interface to copy back and forth between
+       * memory spaces, including between the same memory spaces.
+       *
+       * @note The VectorStorage must be pre-allocated appropriately
+       *
+       * @tparam memorySpaceSrc memory space of the source VectorStorage
+       *  from which to copy
+       * @param[in] srcVectorStorage reference to the source
+       *  VectorStorage
+       */
+      template <dftefe::utils::MemorySpace memorySpaceSrc>
+      void
+      copyFrom(
+        const VectorStorage<ValueType, memorySpaceSrc> &srcVectorStorage);
+
+      /**
+       * @brief Copies data from a VectorStorage object in a different memory space.
+       * This provides a seamless interface to copy back and forth between
+       * memory spaces, including between the same memory spaces.
+       * This is a more granular version of the above copyFrom function as it
+       * provides transfer from a specific portion of the source VectorStorage
+       * to a specific portion of the destination VectorStorage.
+       *
+       * @note The VectorStorage must be pre-allocated appropriately
+       *
+       * @tparam memorySpaceSrc memory space of the source VectorStorage
+       *  from which to copy
+       * @param[in] srcVectorStorage reference to the source
+       *  VectorStorage
+       * @param[in] N number of entries of the source VectorStorage
+       *  that needs to be copied to the destination VectorStorage
+       * @param[in] srcOffset offset relative to the start of the source
+       *  VectorStorage from which we need to copy data
+       * @param[in] dstOffset offset relative to the start of the destination
+       *  VectorStorage to which we need to copy data
+       */
+      template <dftefe::utils::MemorySpace memorySpaceSrc>
+      void
+      copyFrom(VectorStorage<ValueType, memorySpaceSrc> &srcVectorStorage,
+               const size_type                           N,
+               const size_type                           srcOffset,
+               const size_type                           dstOffset);
 
     private:
       ValueType *d_data = nullptr;

--- a/src/utils/VectorStorage.t.cpp
+++ b/src/utils/VectorStorage.t.cpp
@@ -57,13 +57,13 @@ namespace dftefe
       if (size > 0)
         {
           dftefe::utils::MemoryManager<ValueType, memorySpace>::allocate(
-              size, &d_data);
+            size, &d_data);
           dftefe::utils::MemoryManager<ValueType, memorySpace>::set(size,
                                                                     d_data,
                                                                     initVal);
         }
       else
-	d_data = nullptr;
+        d_data = nullptr;
     }
 
     //

--- a/src/utils/VectorStorage.t.cpp
+++ b/src/utils/VectorStorage.t.cpp
@@ -56,13 +56,14 @@ namespace dftefe
       d_size = size;
       if (size > 0)
         {
-          d_data =
-            dftefe::utils::MemoryManager<ValueType, memorySpace>::allocate(
-              size, nullptr);
+          dftefe::utils::MemoryManager<ValueType, memorySpace>::allocate(
+              size, &d_data);
           dftefe::utils::MemoryManager<ValueType, memorySpace>::set(size,
                                                                     d_data,
                                                                     initVal);
         }
+      else
+	d_data = nullptr;
     }
 
     //
@@ -194,6 +195,79 @@ namespace dftefe
     VectorStorage<ValueType, memorySpace>::data() const noexcept
     {
       return d_data;
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    template <dftefe::utils::MemorySpace memorySpaceDst>
+    void
+    VectorStorage<ValueType, memorySpace>::copyTo(
+      VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage) const
+    {
+      throwException<DomainError>(
+        d_size == dstVectorStorage.size(),
+        "The source and destination VectorStorage are of different sizes");
+      MemoryTransfer<memorySpaceDst, memorySpace>::copy(
+        d_size, dstVectorStorage.begin(), this->begin());
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    template <dftefe::utils::MemorySpace memorySpaceDst>
+    void
+    VectorStorage<ValueType, memorySpace>::copyTo(
+      VectorStorage<ValueType, memorySpaceDst> &dstVectorStorage,
+      const size_type                           N,
+      const size_type                           srcOffset,
+      const size_type                           dstOffset) const
+    {
+      throwException<DomainError>(
+        srcOffset + N <= d_size,
+        "The offset and copy size specified for the source VectorStorage"
+        " is out of range for it.");
+
+      throwException<DomainError>(
+        dstOffset + N <= dstVectorStorage.size(),
+        "The offset and size specified for the destination VectorStorage"
+        " is out of range for it.");
+
+      MemoryTransfer<memorySpaceDst, memorySpace>::copy(
+        N, dstVectorStorage.begin() + dstOffset, this->begin() + srcOffset);
+    }
+
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    template <dftefe::utils::MemorySpace memorySpaceSrc>
+    void
+    VectorStorage<ValueType, memorySpace>::copyFrom(
+      const VectorStorage<ValueType, memorySpaceSrc> &srcVectorStorage)
+    {
+      throwException<DomainError>(
+        d_size == srcVectorStorage.size(),
+        "The source and destination VectorStorage are of different sizes");
+      MemoryTransfer<memorySpace, memorySpaceSrc>::copy(
+        d_size, this->begin(), srcVectorStorage.begin());
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    template <dftefe::utils::MemorySpace memorySpaceSrc>
+    void
+    VectorStorage<ValueType, memorySpace>::copyFrom(
+      VectorStorage<ValueType, memorySpaceSrc> &srcVectorStorage,
+      const size_type                           N,
+      const size_type                           srcOffset,
+      const size_type                           dstOffset)
+    {
+      throwException<DomainError>(
+        srcOffset + N <= srcVectorStorage.size(),
+        "The offset and copy size specified for the source VectorStorage"
+        " is out of range for it.");
+
+      throwException<DomainError>(
+        dstOffset + N <= d_size,
+        "The offset and size specified for the destination VectorStorage"
+        " is out of range for it.");
+
+      MemoryTransfer<memorySpace, memorySpaceSrc>::copy(
+        N, this->begin() + dstOffset, srcVectorStorage.begin() + srcOffset);
     }
 
   } // namespace utils


### PR DESCRIPTION
The resize member function in VectorStorage was erroneously passing a nullptr to MemoryManager::allocate instead of  &d_data