### PR TITLE
Add ntasks to ReFrame and remove (?-i) regex modifier

### DIFF
--- a/test/SetupSystems.py
+++ b/test/SetupSystems.py
@@ -33,7 +33,8 @@ def getValidSystems(key):
 
         return returnVal
 
-def setResources(archTag = 'both', time_limit = "00:02:00", num_nodes = 1, num_tasks_per_node = 1, mem_per_cpu =
+def setResources(archTag = 'both', time_limit = "00:02:00", num_nodes = 1,
+                 num_tasks_per_node = 1, ntasks = 1, mem_per_cpu =
                  '2gb', gpus_per_node = 1):
     if archTag.lower() not in ["cpu", "gpu", "both"]:
         msg = '''The tag passed should be one of: 'cpu', 'gpu', or
@@ -46,6 +47,7 @@ def setResources(archTag = 'both', time_limit = "00:02:00", num_nodes = 1, num_t
             'time_limit': time_limit,
             'num_nodes': num_nodes,
             'num_tasks_per_node': num_tasks_per_node,
+            'ntasks' : ntasks,
             'mem_per_cpu': mem_per_cpu
         }
 
@@ -54,6 +56,7 @@ def setResources(archTag = 'both', time_limit = "00:02:00", num_nodes = 1, num_t
             'time_limit': time_limit,
             'num_nodes': num_nodes,
             'num_tasks_per_node': num_tasks_per_node,
+            'ntasks' : ntasks,
             'mem_per_cpu': mem_per_cpu,
             'gpus_per_node': gpus_per_node
         }
@@ -63,6 +66,7 @@ def setResources(archTag = 'both', time_limit = "00:02:00", num_nodes = 1, num_t
             'time_limit': time_limit,
             'num_nodes': num_nodes,
             'num_tasks_per_node': num_tasks_per_node,
+            'ntasks' : ntasks,
             'mem_per_cpu': mem_per_cpu
         }
         returnVal['gpu'] = {
@@ -70,6 +74,7 @@ def setResources(archTag = 'both', time_limit = "00:02:00", num_nodes = 1, num_t
             'num_nodes': num_nodes,
             'num_tasks_per_node': num_tasks_per_node,
             'mem_per_cpu': mem_per_cpu,
+            'ntasks' : ntasks,
             'gpus_per_node': gpus_per_node
         }
 

--- a/test/TestBoilerPlate.py
+++ b/test/TestBoilerPlate.py
@@ -121,12 +121,12 @@ class BuildOnly(rfm.CompileOnlyRegressionTest):
         hasError = True
         msgWarning = "Found warning(s) while compiling."
         msgError = "Found error(s) while compiling."
-        matches = evaluate(sn.findall(r'(?i)warning(?-i)', evaluate(self.stdout)))
+        matches = evaluate(sn.findall(r'(?i)warning', evaluate(self.stdout)))
         if len(matches) == 0:
             hasWarning = False
 
-        matchesOut = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stdout)))
-        matchesErr = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stderr)))
+        matchesOut = evaluate(sn.findall(r'(?i)error', evaluate(self.stdout)))
+        matchesErr = evaluate(sn.findall(r'(?i)error', evaluate(self.stderr)))
         if len(matchesOut) == 0 and len(matchesErr) == 0:
             hasError = False
         

--- a/test/config/mysettings.py
+++ b/test/config/mysettings.py
@@ -42,6 +42,7 @@ site_configuration = {
                                         '--time={time_limit}',
                                         '--nodes={num_nodes}',
                                         '--ntasks-per-node={num_tasks_per_node}',
+                                        '--ntasks={ntasks}',
                                         '--mem-per-cpu={mem_per_cpu}']
                         }
                     ]
@@ -60,6 +61,7 @@ site_configuration = {
                                         '--nodes={num_nodes}',
                                         '--gpus-per-node={gpus_per_node}'
                                         '--ntasks-per-node={num_tasks_per_node}',
+                                        '--ntasks={ntasks}',
                                         '--mem-per-cpu={mem_per_cpu}']
                         }
                     ]

--- a/test/linearAlgebra/TestLinearAlgebraBuild.py
+++ b/test/linearAlgebra/TestLinearAlgebraBuild.py
@@ -77,12 +77,12 @@ class BuildOnly_TestLinearAlgebra(rfm.CompileOnlyRegressionTest):
         hasError = True
         msgWarning = "Found warning(s) while compiling."
         msgError = "Found error(s) while compiling."
-        matches = evaluate(sn.findall(r'(?i)warning(?-i)', evaluate(self.stdout)))
+        matches = evaluate(sn.findall(r'(?i)warning', evaluate(self.stdout)))
         if len(matches) == 0:
             hasWarning = False
 
-        matchesOut = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stdout)))
-        matchesErr = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stderr)))
+        matchesOut = evaluate(sn.findall(r'(?i)error', evaluate(self.stdout)))
+        matchesErr = evaluate(sn.findall(r'(?i)error', evaluate(self.stderr)))
         if len(matchesOut) == 0 and len(matchesErr) == 0:
             hasError = False
         

--- a/test/utils/TestCubicSplineTK.py
+++ b/test/utils/TestCubicSplineTK.py
@@ -56,12 +56,12 @@ class TestCubicSplineTK(rfm.CompileOnlyRegressionTest):
         hasError = True
         msgWarning = "Found warning(s) while compiling."
         msgError = "Found error(s) while compiling."
-        matches = evaluate(sn.findall(r'(?i)warning(?-i)', evaluate(self.stdout)))
+        matches = evaluate(sn.findall(r'(?i)warning', evaluate(self.stdout)))
         if len(matches) == 0:
             hasWarning = False
 
-        matchesOut = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stdout)))
-        matchesErr = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stderr)))
+        matchesOut = evaluate(sn.findall(r'(?i)error', evaluate(self.stdout)))
+        matchesErr = evaluate(sn.findall(r'(?i)error', evaluate(self.stderr)))
         if len(matchesOut) == 0 and len(matchesErr) == 0:
             hasError = False
         

--- a/test/utils/TestMPIRequestersNBX.py
+++ b/test/utils/TestMPIRequestersNBX.py
@@ -91,12 +91,12 @@ class TestMPIRequestersNBXBuildOnly(rfm.CompileOnlyRegressionTest):
         hasError = True
         msgWarning = "Found warning(s) while compiling."
         msgError = "Found error(s) while compiling."
-        matches = evaluate(sn.findall(r'(?i)warning(?-i)', evaluate(self.stdout)))
+        matches = evaluate(sn.findall(r'(?i)warning', evaluate(self.stdout)))
         if len(matches) == 0:
             hasWarning = False
 
-        matchesOut = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stdout)))
-        matchesErr = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stderr)))
+        matchesOut = evaluate(sn.findall(r'(?i)error', evaluate(self.stdout)))
+        matchesErr = evaluate(sn.findall(r'(?i)error', evaluate(self.stderr)))
         if len(matchesOut) == 0 and len(matchesErr) == 0:
             hasError = False
         
@@ -162,18 +162,18 @@ class TestMPIRequestersNBXNode1Tasks10BuildAndRun(rfm.RegressionTest):
         msgError = "Found error(s) in TestMPIRequestersNBX."
         msgThrownException = "Found exceptions in TestMPIRequestersNBX."
         msgAssertFail = "Found assert fail(s) in TestMPIRequestersNBX."
-        matchesOut = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stdout)))
-        matchesErr = evaluate(sn.findall(r'(?i)error(?-i)', evaluate(self.stderr)))
+        matchesOut = evaluate(sn.findall(r'(?i)error', evaluate(self.stdout)))
+        matchesErr = evaluate(sn.findall(r'(?i)error', evaluate(self.stderr)))
         if len(matchesOut) == 0 and len(matchesErr) == 0:
             hasError = False
 
-        matchesOut = evaluate(sn.findall(r'(?i)assert(?-i)', evaluate(self.stdout)))
-        matchesErr = evaluate(sn.findall(r'(?i)assert(?-i)', evaluate(self.stderr)))
+        matchesOut = evaluate(sn.findall(r'(?i)assert', evaluate(self.stdout)))
+        matchesErr = evaluate(sn.findall(r'(?i)assert', evaluate(self.stderr)))
         if len(matchesOut) == 0 and len(matchesErr) == 0:
             hasAssertFail = False
         
-        matchesOut = evaluate(sn.findall(r'(?i)throw(?-i)', evaluate(self.stdout)))
-        matchesErr = evaluate(sn.findall(r'(?i)throw(?-i)', evaluate(self.stderr)))
+        matchesOut = evaluate(sn.findall(r'(?i)throw', evaluate(self.stdout)))
+        matchesErr = evaluate(sn.findall(r'(?i)throw', evaluate(self.stderr)))
         if len(matchesOut) == 0 and len(matchesErr) == 0:
             hasThrownException = False
         


### PR DESCRIPTION
1. In ReFrame, while setting the resources for the run, it defaults the --ntasks=1, irrespective of how many nodes and --ntasks-per-node is being set. So, I've added an ntasks argument to the setResources() function in SetupSystems.py in test/ as well as to config/mysettings.py in test/
2. The case insensitive regex for error/warning/assert etc we were using (e.g., r'(?i)warning(?-i)') is not supported by python properly. Specifically, the beginning (?i) (which turns the case insensitive mode ON) is recognized by python but the ending (?-i) (which turns the case insensitive mode OFF) is not recognized by python. The easiest fix is to remove the ending (?-i)