### PR TITLE
Exclude shell scripts in test/BinaryCopier

### DIFF
--- a/test/BinaryCopier.py
+++ b/test/BinaryCopier.py
@@ -30,6 +30,15 @@ the beginning of the file
 , and the following line has to be added to the test python file.
     bincpy.BinCpy(os.path.dirname(os.path.abspath(__file__)))
 '''
+
+'''
+Returns true if a file is an executable.
+It excludes shell scripts (i.e., those ending with .sh).
+'''
+def isFileExecutable(fpath):
+    return (os.access(fpath, os.X_OK))  and (fpath[-3:] != '.sh')
+
+
 def BinCpy(dir):
     [dir_path, dir_name] = os.path.split(dir)
     exe_path = dir_path+"/"+dir_name+"/executable"
@@ -40,10 +49,6 @@ def BinCpy(dir):
         f = os.path.join(os.getcwd(), filename)
         # checking if it is a file
         if os.path.isfile(f):
-            if(os.access(f, os.X_OK)):
+            # checking it is an executable 
+            if isFileExecutable(f):
                 shutil.copy2(f, exe_path)
-
-    #exe_files = glob.iglob(os.path.join(os.getcwd(), "*.x"))
-    #for file in exe_files:
-    #    if os.path.isfile(file):
-    #        shutil.copy2(file, exe_path)


### PR DESCRIPTION
Modified the BinaryCopier in test/ to exclude shell scripts from the list of executables. 