### PR TITLE
Add copy to and from STL in MemoryStorage

### DIFF
--- a/src/utils/MemoryStorage.h
+++ b/src/utils/MemoryStorage.h
@@ -210,6 +210,8 @@ namespace dftefe
        *  MemoryStorage. It must be pre-allocated appropriately
        * @param[out] dstMemoryStorage reference to the destination
        *  MemoryStorage with the data copied into it
+       * @throw utils::LengthError exception if the size of dstMemoryStorage is
+       * less than underlying MemoryStorage
        */
       template <dftefe::utils::MemorySpace memorySpaceDst>
       void
@@ -236,6 +238,10 @@ namespace dftefe
        *  MemoryStorage to which we need to copy data
        * @param[out] dstMemoryStorage reference to the destination
        *  MemoryStorage with the data copied into it
+       * @throw utils::LengthError exception if the size of dstMemoryStorage is
+       * less than N + dstOffset
+       * @throw utils::LengthError exception if the size of underlying
+       * MemoryStorage is less than N + srcOffset
        */
       template <dftefe::utils::MemorySpace memorySpaceDst>
       void
@@ -255,6 +261,8 @@ namespace dftefe
        *  from which to copy
        * @param[in] srcMemoryStorage reference to the source
        *  MemoryStorage
+       * @throw utils::LengthError exception if the size of underlying
+       * MemoryStorage is less than size of srcMemoryStorage
        */
       template <dftefe::utils::MemorySpace memorySpaceSrc>
       void
@@ -281,6 +289,10 @@ namespace dftefe
        *  MemoryStorage from which we need to copy data
        * @param[in] dstOffset offset relative to the start of the destination
        *  MemoryStorage to which we need to copy data
+       * @throw utils::LengthError exception if the size of srcMemoryStorage is
+       * less than N + srcOffset
+       * @throw utils::LengthError exception if the size of underlying
+       * MemoryStorage is less than N + dstOffset
        */
       template <dftefe::utils::MemorySpace memorySpaceSrc>
       void
@@ -294,7 +306,8 @@ namespace dftefe
        * This provides a seamless interface to copy back and forth between
        * memory spaces, including between the same memory spaces.
        *
-       * @note The destination pointer must be pre-allocated appropriately
+       * @note The destination pointer must be pre-allocated to be
+       * at least of the size of the MemoryStorage
        *
        * @tparam memorySpaceDst memory space of the destination pointer
        * @param[in] dst pointer to the destination. It must be pre-allocated
@@ -313,7 +326,8 @@ namespace dftefe
        * transfer from a specific portion of the source MemoryStorage to a
        * specific portion of the destination pointer.
        *
-       * @note The destination pointer must be pre-allocated appropriately
+       * @note The destination pointer must be pre-allocated to be at least
+       * of the size N + dstOffset
        *
        * @tparam memorySpaceDst memory space of the destination pointer
        * @param[in] dst pointer to the destination. It must be pre-allocated
@@ -325,6 +339,8 @@ namespace dftefe
        * @param[in] dstOffset offset relative to the start of the destination
        *  pointer to which we need to copy data
        * @param[out] dst pointer to the destination with the data copied into it
+       * @throw utils::LengthError exception if the size of the MemoryStorage is
+       * less than N + srcOffset
        */
       template <dftefe::utils::MemorySpace memorySpaceDst>
       void
@@ -339,7 +355,8 @@ namespace dftefe
        * This provides a seamless interface to copy back and forth between
        * memory spaces, including between the same memory spaces.
        *
-       * @note The MemoryStorage must be pre-allocated appropriately
+       * @note The src pointer must point to a memory chunk that is at least the
+       * size of the MemoryStorage
        *
        * @tparam memorySpaceSrc memory space of the source pointer
        *  from which to copy
@@ -357,7 +374,8 @@ namespace dftefe
        * provides transfer from a specific portion of the source memory
        * to a specific portion of the destination MemoryStorage.
        *
-       * @note The MemoryStorage must be pre-allocated appropriately
+       * @note The src pointer must point to a memory chunk that is at least
+       * the size of N + srcOffset
        *
        * @tparam memorySpaceSrc memory space of the source pointer
        *  from which to copy
@@ -368,6 +386,8 @@ namespace dftefe
        *  pointer from which we need to copy data
        * @param[in] dstOffset offset relative to the start of the destination
        *  MemoryStorage to which we need to copy data
+       * @throw utils::LengthError exception if the size of the MemoryStorage is
+       * less than N + dstOffset
        */
       template <dftefe::utils::MemorySpace memorySpaceSrc>
       void
@@ -376,10 +396,128 @@ namespace dftefe
                const size_type  srcOffset,
                const size_type  dstOffset);
 
+      /**
+       * @brief Copies the data to a C++ STL vector, which always resides in
+       * the CPU. This provides a seamless interface to copy from any memory
+       * space to a C++ STL vector, including the case where source memory space
+       * is HOST (i.e., it resides on the CPU)
+       *
+       * @param[in] dst reference to the destination C++ STL vector to which
+       *  the data needs to be copied.
+       * @param[out] dst reference to the destination C++ STL vector with
+       * the data copied into it
+       * @note If the size of the dst vector is less than the the size of
+       * the underlying MemoryStorage, it will be resized. Thus, for performance
+       * reasons, it is recommened that the dst STL vector be pre-allocated
+       * appropriately.
+       */
+      void
+      copyTo(std::vector<ValueType> &dst) const;
+
+      /**
+       * @brief Copies the data to a C++ STL vector, which always resides in
+       * the CPU. This provides a seamless interface to copy from any memory
+       * space to a C++ STL vector, including the case where source memory space
+       * is HOST (i.e., it resides on the CPU).
+       * This is a more granular version of the above copyToSTL function as it
+       * provides transfer from a specific portion of the MemoryStorage
+       * to a specific portion of the destination STL vector.
+       *
+       * @param[in] dst reference to the destination C++ STL vector to which
+       *  the data needs to be copied.
+       * @note If the size of the dst vector is less than the the size of
+       * the underlying memory storage, it will be resized. Thus, for
+       * performance reasons it is recommened to should be allocated
+       * appropriately.
+       * @param[in] N number of entries of the source MemoryStorage
+       *  that needs to be copied to the destination pointer
+       * @param[in] srcOffset offset relative to the start of the source
+       *  MemoryStorage from which we need to copy data
+       * @param[in] dstOffset offset relative to the start of the STL vector
+       *  to which we need to copy data
+       * @param[out] dst reference to the destination C++ STL vector with
+       * the data copied into it
+       * @throw utils::LengthError exception if the size of the MemoryStorage is
+       * less than N + srcOffset
+       * @note If the size of the dst vector is less N + srcOffset, it will be resized.
+       *  Thus, for performance reasons, it is recommened that the dst STL
+       * vector be allocated appropriately.
+       */
+      void
+      copyTo(std::vector<ValueType> &dst,
+             const size_type         N,
+             const size_type         srcOffset,
+             const size_type         dstOffset) const;
+
+      /**
+       * @brief Copies data from a C++ STL vector to the MemoryStorage object,
+       * which always resides on a CPU. This provides a seamless interface to
+       * copy from any memory space, including the case where the same memory
+       * spaces is HOST(i.e., the MemoryStorage is on CPU).
+       *
+       * @param[in] src const reference to the source C++ STL vector from which
+       *  the data needs to be copied.
+       *
+       * @throw utils::LengthError exception if the size of the MemoryStorage is
+       * less than the size of the src
+       */
+      void
+      copyFrom(const std::vector<ValueType> &src);
+
+      /**
+       * @brief Copies data from a C++ STL vector to the MemoryStorage object,
+       * which always resides on a CPU. This provides a seamless interface to
+       * copy from any memory space, including the case where the same memory
+       * spaces is HOST(i.e., the MemoryStorage is on CPU). This is a more
+       * granular version of the above copyFromSTL function as it provides
+       * transfer from a specific portion of the source STL vector to to a
+       * specific portion of the destination MemoryStorage.
+       *
+       * @param[in] src const reference to the source C++ STL vector from which
+       *  the data needs to be copied.
+       * @param[in] N number of entries of the source pointer
+       *  that needs to be copied to the destination MemoryStorage
+       * @param[in] srcOffset offset relative to the start of the source STL
+       *  vector from which we need to copy data
+       * @param[in] dstOffset offset relative to the start of the destination
+       *  MemoryStorage to which we need to copy data
+       * @throw utils::LengthError exception if the size of src is less than
+       * N + srcOffset
+       * @throw utils::LengthError exception if the size of the MemoryStorage
+       * is less thant N + dstOffset
+       *
+       */
+      void
+      copyFrom(const std::vector<ValueType> &src,
+               const size_type               N,
+               const size_type               srcOffset,
+               const size_type               dstOffset);
+
+
     private:
       ValueType *d_data = nullptr;
       size_type  d_size = 0;
     };
+
+    //
+    // helper functions
+    //
+
+    /**
+     * @brief Create a MemoryStorage object from an input C++ STL vector
+     * @param[in] src Input C++ STL vector from which the MemoryStorage
+     *  object is to be created
+     * @return A MemoryStorage object containing the data in the input C++
+     *  STL vector
+     * @tparam ValueType Datatype of the underlying data in MemoryStorage
+     *  as well as C++ STL vector (e.g., int, double, float, complex<double>,
+     *  etc)
+     * @tparam memorySpaceDst MemorySpace (e.g. HOST, DEVICE, HOST_PINNED, etc)
+     * where the output MemoryStorage object should reside
+     */
+    template <ValueType, utils::MemorySpace memorySpaceDst>
+    MemoryStorage<ValueType, memorySpaceDst>
+    memoryStorageFromSTL(const std::vector<ValueType> &src);
 
   } // namespace utils
 } // end of namespace dftefe

--- a/src/utils/MemoryStorage.t.cpp
+++ b/src/utils/MemoryStorage.t.cpp
@@ -211,9 +211,10 @@ namespace dftefe
     MemoryStorage<ValueType, memorySpace>::copyTo(
       MemoryStorage<ValueType, memorySpaceDst> &dstMemoryStorage) const
     {
-      throwException<DomainError>(
-        d_size == dstMemoryStorage.size(),
-        "The source and destination MemoryStorage are of different sizes");
+      throwException<LengthError>(
+        d_size <= dstMemoryStorage.size(),
+        "The allocated size of destination MemoryStorage is insufficient to "
+        "copy from the the MemoryStorage.");
       MemoryTransfer<memorySpaceDst, memorySpace>::copy(
         d_size, dstMemoryStorage.begin(), this->begin());
     }
@@ -227,12 +228,12 @@ namespace dftefe
       const size_type                           srcOffset,
       const size_type                           dstOffset) const
     {
-      throwException<DomainError>(
+      throwException<LengthError>(
         srcOffset + N <= d_size,
         "The offset and copy size specified for the source MemoryStorage"
         " is out of range for it.");
 
-      throwException<DomainError>(
+      throwException<LengthError>(
         dstOffset + N <= dstMemoryStorage.size(),
         "The offset and size specified for the destination MemoryStorage"
         " is out of range for it.");
@@ -248,11 +249,12 @@ namespace dftefe
     MemoryStorage<ValueType, memorySpace>::copyFrom(
       const MemoryStorage<ValueType, memorySpaceSrc> &srcMemoryStorage)
     {
-      throwException<DomainError>(
-        d_size == srcMemoryStorage.size(),
-        "The source and destination MemoryStorage are of different sizes");
+      throwException<LengthError>(
+        srcMemoryStorage.size() <= d_size,
+        "The allocated size of the MemoryStorage is insufficient to "
+        " copy from the source MemoryStorage.");
       MemoryTransfer<memorySpace, memorySpaceSrc>::copy(
-        d_size, this->begin(), srcMemoryStorage.begin());
+        srcMemoryStorage.size(), this->begin(), srcMemoryStorage.begin());
     }
 
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
@@ -264,12 +266,12 @@ namespace dftefe
       const size_type                           srcOffset,
       const size_type                           dstOffset)
     {
-      throwException<DomainError>(
+      throwException<LengthError>(
         srcOffset + N <= srcMemoryStorage.size(),
         "The offset and copy size specified for the source MemoryStorage"
         " is out of range for it.");
 
-      throwException<DomainError>(
+      throwException<LengthError>(
         dstOffset + N <= d_size,
         "The offset and size specified for the destination MemoryStorage"
         " is out of range for it.");
@@ -297,7 +299,7 @@ namespace dftefe
       const size_type srcOffset,
       const size_type dstOffset) const
     {
-      throwException<DomainError>(
+      throwException<LengthError>(
         srcOffset + N <= d_size,
         "The offset and copy size specified for the source MemoryStorage"
         " is out of range for it.");
@@ -324,13 +326,91 @@ namespace dftefe
                                                     const size_type  srcOffset,
                                                     const size_type  dstOffset)
     {
-      throwException<DomainError>(
+      throwException<LengthError>(
         dstOffset + N <= d_size,
         "The offset and size specified for the destination MemoryStorage"
         " is out of range for it.");
 
       MemoryTransfer<memorySpace, memorySpaceSrc>::copy(
         N, this->begin() + dstOffset, src + srcOffset);
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    void
+    MemoryStorage<ValueType, memorySpace>::copyTo(
+      std::vector<ValueType> &dst) const
+    {
+      if (dst.size() < d_size)
+        dst.resize(d_size);
+
+      MemoryTransfer<utils::MemorySpace::HOST, memorySpace>::copy(
+        d_size, dst.data(), this->begin());
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    void
+    MemoryStorage<ValueType, memorySpace>::copyTo(
+      std::vector<ValueType> &dst,
+      const size_type         N,
+      const size_type         srcOffset,
+      const size_type         dstOffset) const
+    {
+      throwException<LengthError>(
+        srcOffset + N <= d_size,
+        "The offset and copy size specified for the source MemoryStorage"
+        " is out of range for it.");
+      if (dst.size() < N + dstOffset)
+        dst.resize(N + dstOffset);
+
+      MemoryTransfer<utils::MemorySpace::HOST, memorySpace>::copy(
+        N, dst.data() + dstOffset, this->begin() + srcOffset);
+    }
+
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    void
+    MemoryStorage<ValueType, memorySpace>::copyFrom(
+      const std::vector<ValueType> &src)
+    {
+      throwException<LengthError>(
+        src.size() <= d_size,
+        "The allocated size of the MemoryStorage is insufficient to copy from "
+        "the source STL vector");
+      MemoryTransfer<memorySpace, utils::MemorySpace::HOST>::copy(src.size(),
+                                                                  this->begin(),
+                                                                  src.data());
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    void
+    MemoryStorage<ValueType, memorySpace>::copyFrom(
+      const std::vector<ValueType> &src,
+      const size_type               N,
+      const size_type               srcOffset,
+      const size_type               dstOffset)
+    {
+      throwException<LengthError>(
+        dstOffset + N <= d_size,
+        "The offset and size specified for the destination MemoryStorage"
+        " is out of range for it.");
+
+      throwException<LengthError>(
+        srcOffset + N <= src.size(),
+        "The offset and size specified for the source STL vector "
+        " is out of range for it.");
+
+      MemoryTransfer<memorySpace, utils::MemorySpace::HOST>::copy(
+        N, this->begin() + dstOffset, src.data() + srcOffset);
+    }
+
+    template <ValueType, utils::MemorySpace memorySpaceDst>
+    MemoryStorage<ValueType, memorySpaceDst>
+    memoryStorageFromSTL(const std::vector<ValueType> &src)
+    {
+      MemoryStorage<ValueType, memorySpaceDst> returnValue(src.size());
+      MemoryTransfer<memorySpaceDst, utils::MemorySpace::HOST>::copy(
+        src.size(), returnValue.begin(), src.data());
+      return returnValue;
     }
 
   } // namespace utils


### PR DESCRIPTION
- Added two copyTo and copyFrom function overloads in MemoryStorage for copying back and forth from STL. They mimic the other copyTo and copyFrom member functions, albeit without a second MemorySpace (because the STL's memory space is always HOST). This helps in writing more concise code in the user side where we have to create many temporary STLs and then copy the data to a MemoryStorage (of any memory space). Without these overloads the user side code gets scattered with hardcoded MemorySpace::HOST template to copy to or from an STL. 

- For the copyTo and copyFrom overloads that uses another MemoryStorage in the input argument, we were previously throwing an Exception if the input MemoryStorage was of different size than the `this` MemoryStorage. However, the correct behavior is to throw Exception only if the destination MemoryStorage (can be the input or the `this` MemoryStorage depending whether it is copyTo or copyFrom function) is smaller in size than the source MemoryStorage