### PR TITLE
Add compatibitlity checks to OptimizedIndexSet MPIPatternP2P Vector and MultiVector

### DIFF
--- a/src/linearAlgebra/MultiVector.h
+++ b/src/linearAlgebra/MultiVector.h
@@ -395,6 +395,9 @@ namespace dftefe
       void
       accumulateAddLocallyOwnedEnd();
 
+      bool
+      isCompatible(const MultiVector<ValueType, memorySpace> &rhs) const;
+
     private:
       std::unique_ptr<Storage>      d_storage;
       LinAlgOpContext<memorySpace> *d_linAlgOpContext;

--- a/src/linearAlgebra/MultiVector.t.cpp
+++ b/src/linearAlgebra/MultiVector.t.cpp
@@ -561,5 +561,27 @@ namespace dftefe
     {
       d_mpiCommunicatorP2P->accumulateAddLocallyOwnedEnd(*d_storage);
     }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    bool
+    MultiVector<ValueType, memorySpace>::isCompatible(
+      const MultiVector<ValueType, memorySpace> &rhs) const
+    {
+      if (d_vectorAttributes.areDistributionCompatible(
+            rhs.d_vectorAttributes) == false)
+        return false;
+      else if (d_numVectors != rhs.d_numVectors)
+        return false;
+      else if (d_globalSize != rhs.d_globalSize)
+        return false;
+      else if (d_localSize != rhs.d_localSize)
+        return false;
+      else if (d_locallyOwnedSize != rhs.d_locallyOwnedSize)
+        return false;
+      else if (d_ghostSize != rhs.d_ghostSize)
+        return false;
+      else
+        return (d_mpiPatternP2P->isCompatible(*(rhs.d_mpiPatternP2P)));
+    }
   } // end of namespace linearAlgebra
 } // namespace dftefe

--- a/src/linearAlgebra/Vector.h
+++ b/src/linearAlgebra/Vector.h
@@ -362,6 +362,9 @@ namespace dftefe
       void
       accumulateAddLocallyOwnedEnd();
 
+      bool
+      isCompatible(const Vector<ValueType, memorySpace> &rhs) const;
+
     private:
       std::unique_ptr<Storage>      d_storage;
       LinAlgOpContext<memorySpace> *d_linAlgOpContext;

--- a/src/linearAlgebra/Vector.t.cpp
+++ b/src/linearAlgebra/Vector.t.cpp
@@ -539,6 +539,25 @@ namespace dftefe
       d_mpiCommunicatorP2P->accumulateAddLocallyOwnedEnd(*d_storage);
     }
 
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    bool
+    Vector<ValueType, memorySpace>::isCompatible(
+      const Vector<ValueType, memorySpace> &rhs)
+    {
+      if (d_vectorAttributes.areDistributionCompatible(
+            rhs.d_vectorAttributes) == false)
+        return false;
+      else if (d_globalSize != rhs.d_globalSize)
+        return false;
+      else if (d_localSize != rhs.d_localSize)
+        return false;
+      else if (d_locallyOwnedSize != rhs.d_locallyOwnedSize)
+        return false;
+      else if (d_ghostSize != rhs.d_ghostSize)
+        return false;
+      else
+        return (d_mpiPatternP2P->isCompatible(*(rhs.d_mpiPatternP2P)));
+    }
 
 
     //

--- a/src/utils/MPIPatternP2P.h
+++ b/src/utils/MPIPatternP2P.h
@@ -192,6 +192,9 @@ namespace dftefe
         const MPIComm &
         mpiCommunicator() const;
 
+        bool
+        isCompatible(const MPIPatternP2P<memorySpace> &rhs) const;
+
       private:
         /**
          * A pair \f$(a,b)\f$ which defines a range of indices (continuous)

--- a/src/utils/MPIPatternP2P.t.cpp
+++ b/src/utils/MPIPatternP2P.t.cpp
@@ -589,6 +589,11 @@ namespace dftefe
         for (unsigned int i = 0; i < d_nprocs; ++i)
           d_nGlobalIndices +=
             d_allOwnedRanges[2 * i + 1] - d_allOwnedRanges[2 * i];
+
+        // set the d_ghostIndicesSetSTL to be of size zero
+        d_ghostIndicesSetSTL.clear();
+        d_ghostIndicesOptimizedIndexSet =
+          OptimizedIndexSet<global_size_type>(d_ghostIndicesSetSTL);
       }
 
 #endif
@@ -617,6 +622,11 @@ namespace dftefe
       {
         d_myRank = 0;
         d_nprocs = 1;
+        throwException(
+          d_locallyOwnedRange.second >= d_locallyOwnedRange.first,
+          "In processor " + std::to_string(d_myRank) +
+            ", invalid locally owned range found "
+            "(i.e., the second value in the range is less than the first value).");
         d_numLocallyOwnedIndices =
           d_locallyOwnedRange.second - d_locallyOwnedRange.first;
         std::vector<global_size_type> d_allOwnedRanges = {
@@ -624,6 +634,11 @@ namespace dftefe
         for (unsigned int i = 0; i < d_nprocs; ++i)
           d_nGlobalIndices +=
             d_allOwnedRanges[2 * i + 1] - d_allOwnedRanges[2 * i];
+
+        // set the d_ghostIndicesSetSTL to be of size zero
+        d_ghostIndicesSetSTL.clear();
+        d_ghostIndicesOptimizedIndexSet =
+          OptimizedIndexSet<global_size_type>(d_ghostIndicesSetSTL);
       }
 
       template <dftefe::utils::MemorySpace memorySpace>
@@ -929,6 +944,28 @@ namespace dftefe
         size_type localId;
         d_ghostIndicesOptimizedIndexSet.getPosition(globalId, localId, found);
         return found;
+      }
+
+      template <dftefe::utils::MemorySpace memorySpace>
+      bool
+      MPIPatternP2P<memorySpace>::isCompatible(
+        const MPIPatternP2P<memorySpace> &rhs) const
+      {
+        if (d_nprocs != rhs.d_nprocs)
+          return false;
+
+        else if (d_nGlobalIndices != rhs.d_nGlobalIndices)
+          return false;
+
+        else if (d_locallyOwnedRange != rhs.d_locallyOwnedRange)
+          return false;
+
+        else if (d_numGhostIndices != rhs.d_numGhostIndices)
+          return false;
+
+        else
+          return (d_ghostIndicesOptimizedIndexSet ==
+                  rhs.d_ghostIndicesOptimizedIndexSet);
       }
     } // end of namespace mpi
   }   // end of namespace utils

--- a/src/utils/OptimizedIndexSet.h
+++ b/src/utils/OptimizedIndexSet.h
@@ -39,10 +39,6 @@ namespace dftefe
      * are fewer compared to the size of the index set. If the number of
      * contiguous sub-ranges competes with the size of the index set (i.e., the
      * index set is very random) then it default to the behavior of an std::set.
-     * The default to STL set is governed by the numRangesToSetSizeTol value.
-     * That is, if the ratio of number of contiguous ranges to the size of index
-     * set exceeds numRangesToSetSizeTol, it defaults to the behavior of STL
-     * set. The default value for numRangesToSetSizeTol is 0.1
      *
      * @tparam ValueType The data type of the indices (e.g., unsigned int, unsigned long int)
      */
@@ -51,6 +47,12 @@ namespace dftefe
     class OptimizedIndexSet
     {
     public:
+      /**
+       * @brief Constructor
+       *
+       * @param[in] inputSet A set of unsigned int or unsigned long int
+       * for which an OptimizedIndexSet is to be created
+       */
       OptimizedIndexSet(const std::set<T> &inputSet = std::set<T>());
       ~OptimizedIndexSet() = default;
 
@@ -73,6 +75,9 @@ namespace dftefe
       /// Vector of size d_numContiguousRanges which stores the accumulated
       /// number of elements in d_set prior to the i-th contiguous range
       std::vector<size_type> d_numEntriesBefore;
+
+      bool
+      operator==(const OptimizedIndexSet<T> &rhs) const;
     };
 
   } // end of namespace utils

--- a/src/utils/OptimizedIndexSet.t.cpp
+++ b/src/utils/OptimizedIndexSet.t.cpp
@@ -31,9 +31,15 @@ namespace dftefe
 {
   namespace utils
   {
+    //
+    // Constructor
+    //
     template <typename T>
-    OptimizedIndexSet<T>::OptimizedIndexSet(const std::set<T> &inputSet)
-      : d_contiguousRanges(0)
+    OptimizedIndexSet<T>::OptimizedIndexSet(
+      const std::set<T> &inputSet /*=std::set<T>()*/)
+      : d_numContiguousRanges(0)
+      , d_contiguousRanges(0)
+      , d_numEntriesBefore(0)
     {
       bool isValid = std::is_same<size_type, T>::value ||
                      std::is_same<global_size_type, T>::value;
@@ -103,17 +109,30 @@ namespace dftefe
        * index lies
        */
 
-      auto      up    = std::upper_bound(d_contiguousRanges.begin(),
+      auto up = std::upper_bound(d_contiguousRanges.begin(),
                                  d_contiguousRanges.end(),
                                  index);
-      size_type upPos = std::distance(d_contiguousRanges.begin(), up);
-      if (upPos % 2 == 1)
+      if (up != d_contiguousRanges.end())
         {
-          found             = true;
-          size_type rangeId = upPos / 2;
-          pos =
-            d_numEntriesBefore[rangeId] + index - d_contiguousRanges[upPos - 1];
+          size_type upPos = std::distance(d_contiguousRanges.begin(), up);
+          if (upPos % 2 == 1)
+            {
+              found             = true;
+              size_type rangeId = upPos / 2;
+              pos               = d_numEntriesBefore[rangeId] + index -
+                    d_contiguousRanges[upPos - 1];
+            }
         }
+    }
+
+    template <typename T>
+    bool
+    OptimizedIndexSet<T>::getPosition(const OptimizedIndexSet<T> &rhs) const
+    {
+      if (d_numContiguousRanges != rhs.d_numContiguousRanges)
+        return false;
+      else
+        return (d_contiguousRanges == rhs.d_contiguousRanges);
     }
   } // end of namespace utils
 } // end of namespace dftefe


### PR DESCRIPTION
- Add an operator==() overload in OptimizedIndex to check if two objects have the same contiguous ranges
- Add an isCompatible() function in MPIPatternP2P to check if two MPIPatternP2P objects are compatible (i.e., same number of procs, same locally owned range, same ghost indices, etc)
- Add isCompatible() function in Vector and MultiVector tow check if two Vectors/MultiVectors are compatible (it internally checks the compatibility of their underlying MPIPatternP2P objects)