### PR TITLE
Add getMPIPatternP2P() to Vector and MultiVector

### DIFF
--- a/src/linearAlgebra/MultiVector.h
+++ b/src/linearAlgebra/MultiVector.h
@@ -398,6 +398,9 @@ namespace dftefe
       bool
       isCompatible(const MultiVector<ValueType, memorySpace> &rhs) const;
 
+      std::shared_ptr<const utils::mpi::MPIPatternP2P<memorySpace>>
+      getMPIPatternP2P() const;
+
     private:
       std::unique_ptr<Storage>      d_storage;
       LinAlgOpContext<memorySpace> *d_linAlgOpContext;

--- a/src/linearAlgebra/MultiVector.t.cpp
+++ b/src/linearAlgebra/MultiVector.t.cpp
@@ -583,5 +583,12 @@ namespace dftefe
       else
         return (d_mpiPatternP2P->isCompatible(*(rhs.d_mpiPatternP2P)));
     }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    std::shared_ptr<const utils::mpi::MPIPatternP2P<memorySpace>>
+    MultiVector<ValueType, memorySpace>::getMPIPatternP2P() const
+    {
+      return d_mpiPatternP2P;
+    }
   } // end of namespace linearAlgebra
 } // namespace dftefe

--- a/src/linearAlgebra/Vector.h
+++ b/src/linearAlgebra/Vector.h
@@ -365,6 +365,9 @@ namespace dftefe
       bool
       isCompatible(const Vector<ValueType, memorySpace> &rhs) const;
 
+      std::shared_ptr<const utils::mpi::MPIPatternP2P<memorySpace>>
+      getMPIPatternP2P() const;
+
     private:
       std::unique_ptr<Storage>      d_storage;
       LinAlgOpContext<memorySpace> *d_linAlgOpContext;

--- a/src/linearAlgebra/Vector.t.cpp
+++ b/src/linearAlgebra/Vector.t.cpp
@@ -560,6 +560,13 @@ namespace dftefe
     }
 
 
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    std::shared_ptr<const utils::mpi::MPIPatternP2P<memorySpace>>
+    Vector<ValueType, memorySpace>::getMPIPatternP2P() const
+    {
+      return d_mpiPatternP2P;
+    }
+
     //
     // Helper functions
     //


### PR DESCRIPTION
- Added getMPIPatternP2P() to Vector and MultiVector. This will be useful in checking compatibility of a Vector/MultiVector with a given MPIPatternP2P (say fetched from the BasisHandler for a given constraint ID).