### PR TITLE
Add begin/end iter to Vector and MultiVector

### DIFF
--- a/src/linearAlgebra/MultiVector.h
+++ b/src/linearAlgebra/MultiVector.h
@@ -356,6 +356,56 @@ namespace dftefe
       operator=(MultiVector &&u);
 
       /**
+       * @brief Return iterator pointing to the beginning of MultiVector data.
+       *
+       * @returns Iterator pointing to the beginning of MultiVector.
+       */
+      iterator
+      begin();
+
+      /**
+       * @brief Return iterator pointing to the beginning of MultiVector
+       * data.
+       *
+       * @returns Constant iterator pointing to the beginning of
+       * MultiVector.
+       */
+      const_iterator
+      begin() const;
+
+      /**
+       * @brief Return iterator pointing to the end of MultiVector data.
+       *
+       * @returns Iterator pointing to the end of MultiVector.
+       */
+      iterator
+      end();
+
+      /**
+       * @brief Return iterator pointing to the end of MultiVector data.
+       *
+       * @returns Constant iterator pointing to the end of
+       * MultiVector.
+       */
+      const_iterator
+      end() const;
+
+      /**
+       * @brief Return the raw pointer to the MultiVector data
+       * @return pointer to data
+       */
+      ValueType *
+      data();
+
+      /**
+       * @brief Return the constant raw pointer to the MultiVector data
+       * @return pointer to const data
+       */
+      const ValueType *
+      data() const;
+
+
+      /**
        * @brief Set all entries of the MultiVector to a given value
        *
        * @param[in] val The value to which the entries are to be set

--- a/src/linearAlgebra/MultiVector.t.cpp
+++ b/src/linearAlgebra/MultiVector.t.cpp
@@ -458,6 +458,48 @@ namespace dftefe
     }
 
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    MultiVector<ValueType, memorySpace>::iterator
+    MultiVector<ValueType, memorySpace>::begin()
+    {
+      return d_storage->begin();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    MultiVector<ValueType, memorySpace>::const_iterator
+    MultiVector<ValueType, memorySpace>::begin() const
+    {
+      return d_storage->begin();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    MultiVector<ValueType, memorySpace>::iterator
+    MultiVector<ValueType, memorySpace>::end()
+    {
+      return d_storage->end();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    MultiVector<ValueType, memorySpace>::const_iterator
+    MultiVector<ValueType, memorySpace>::end() const
+    {
+      return d_storage->end();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    ValueType *
+    MultiVector<ValueType, memorySpace>::data()
+    {
+      return d_storage->data();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    const ValueType *
+    MultiVector<ValueType, memorySpace>::data() const
+    {
+      return d_storage->data();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
     void
     MultiVector<ValueType, memorySpace>::setValue(const ValueType val)
     {

--- a/src/linearAlgebra/Vector.h
+++ b/src/linearAlgebra/Vector.h
@@ -323,6 +323,55 @@ namespace dftefe
       operator=(Vector &&u);
 
       /**
+       * @brief Return iterator pointing to the beginning of Vector data.
+       *
+       * @returns Iterator pointing to the beginning of Vector.
+       */
+      iterator
+      begin();
+
+      /**
+       * @brief Return iterator pointing to the beginning of Vector
+       * data.
+       *
+       * @returns Constant iterator pointing to the beginning of
+       * Vector.
+       */
+      const_iterator
+      begin() const;
+
+      /**
+       * @brief Return iterator pointing to the end of Vector data.
+       *
+       * @returns Iterator pointing to the end of Vector.
+       */
+      iterator
+      end();
+
+      /**
+       * @brief Return iterator pointing to the end of Vector data.
+       *
+       * @returns Constant iterator pointing to the end of
+       * Vector.
+       */
+      const_iterator
+      end() const;
+
+      /**
+       * @brief Return the raw pointer to the Vector data
+       * @return pointer to data
+       */
+      ValueType *
+      data();
+
+      /**
+       * @brief Return the constant raw pointer to the Vector data
+       * @return pointer to const data
+       */
+      const ValueType *
+      data() const;
+
+      /**
        * @brief Set all the entries of the Vector to a given value
        * @param[in] val The value to which all the entries in the Vector are
        * to be set

--- a/src/linearAlgebra/Vector.t.cpp
+++ b/src/linearAlgebra/Vector.t.cpp
@@ -443,6 +443,48 @@ namespace dftefe
     }
 
     template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    typename Vector<ValueType, memorySpace>::iterator
+    Vector<ValueType, memorySpace>::begin()
+    {
+      return d_storage->begin();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    typename Vector<ValueType, memorySpace>::const_iterator
+    Vector<ValueType, memorySpace>::begin() const
+    {
+      return d_storage->begin();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    typename Vector<ValueType, memorySpace>::iterator
+    Vector<ValueType, memorySpace>::end()
+    {
+      return d_storage->end();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    typename Vector<ValueType, memorySpace>::const_iterator
+    Vector<ValueType, memorySpace>::end() const
+    {
+      return d_storage->end();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    ValueType *
+    Vector<ValueType, memorySpace>::data()
+    {
+      return d_storage->data();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
+    const ValueType *
+    Vector<ValueType, memorySpace>::data() const
+    {
+      return d_storage->data();
+    }
+
+    template <typename ValueType, dftefe::utils::MemorySpace memorySpace>
     void
     Vector<ValueType, memorySpace>::setValue(const ValueType val)
     {


### PR DESCRIPTION
While simplifying the Vector class from SerialVector/DistributedVector (similarly for MultiVector), I had forgotten to provide begin(), end(), data() member functions. Added them in this PR.