### PR TITLE
Add hadamardProduct and dotMultiVector with conjugate operations

### DIFF
--- a/src/linearAlgebra/BlasLapack.h
+++ b/src/linearAlgebra/BlasLapack.h
@@ -84,9 +84,9 @@ namespace dftefe
       // i have neglected incx & incy parameters
       /**
        * @brief Template for computing the multiplicative inverse of all the elements of x, does not check if any element is zero
-       * computes \f $ y[i] = \frac{alpha}{x[i]} $ \f 
+       * computes \f $ y[i] = \frac{alpha}{x[i]} $ \f
        * @param[in] n size of each vector
-       * @param[in] alpha scalr input for the numerator 
+       * @param[in] alpha scalr input for the numerator
        * @param[in] x input vector
        * @param[out] y output vector
        * @param[in] context Blas context for GPU operations
@@ -136,6 +136,32 @@ namespace dftefe
       hadamardProduct(size_type                            n,
                       const ValueType1 *                   x,
                       const ValueType2 *                   y,
+                      scalar_type<ValueType1, ValueType2> *z,
+                      LinAlgOpContext<memorySpace> &       context);
+      /**
+       * @brief Template for performing \f$ z_i = op(x_i) * op(y_i)$
+       * where op represents either identity or complex conjugate
+       * operation on a scalar
+       * @param[in] size size of the array
+       * @param[in] x array
+       * @param[in] y array
+       * @param[in] opx blasLapack::ScalarOp defining the operation on each
+       * entry of x. The available options are
+       * (a) blasLapack::ScalarOp::Identity (identity operation on a scalar),
+       * and (b) blasLapack::ScalarOp::Conj (complex conjugate on a scalar)
+       * @param[in] opy blasLapack::ScalarOp defining the operation on each
+       * entry of y.
+       * @param[out] z array
+       */
+      template <typename ValueType1,
+                typename ValueType2,
+                typename dftefe::utils::MemorySpace memorySpace>
+      void
+      hadamardProduct(size_type                            n,
+                      const ValueType1 *                   x,
+                      const ValueType2 *                   y,
+                      const ScalarOp &                     opx,
+                      const ScalarOp &                     opy,
                       scalar_type<ValueType1, ValueType2> *z,
                       LinAlgOpContext<memorySpace> &       context);
 
@@ -209,6 +235,12 @@ namespace dftefe
        * vector index is the fastest index
        * @param[in] multiVecDataY multi vector data in row major format i.e.
        * vector index is the fastest index
+       * @param[in] opX blasLapack::ScalarOp defining the operation on each
+       * entry of multiVecDataX. The available options are
+       * (a) blasLapack::ScalarOp::Identity (identity operation on a scalar),
+       * and (b) blasLapack::ScalarOp::Conj (complex conjugate on a scalar)
+       * @param[in] opY blasLapack::ScalarOp defining the operation on each
+       * entry of multiVecDataY.
        * @param[out] multiVecDotProduct multi vector dot product of size numVec
        *
        */
@@ -220,6 +252,8 @@ namespace dftefe
                      size_type                            numVec,
                      const ValueType1 *                   multiVecDataX,
                      const ValueType2 *                   multiVecDataY,
+                     const ScalarOp &                     opX,
+                     const ScalarOp &                     opY,
                      scalar_type<ValueType1, ValueType2> *multiVecDotProduct,
                      LinAlgOpContext<memorySpace> &       context);
 

--- a/src/linearAlgebra/BlasLapack.t.cpp
+++ b/src/linearAlgebra/BlasLapack.t.cpp
@@ -119,6 +119,22 @@ namespace dftefe
           hadamardProduct(n, x, y, z);
       }
 
+      template <typename ValueType1,
+                typename ValueType2,
+                typename dftefe::utils::MemorySpace memorySpace>
+      void
+      hadamardProduct(size_type                            n,
+                      const ValueType1 *                   x,
+                      const ValueType2 *                   y,
+                      const ScalarOp &                     opx,
+                      const ScalarOp &                     opy,
+                      scalar_type<ValueType1, ValueType2> *z,
+                      LinAlgOpContext<memorySpace> &       context)
+      {
+        KernelsTwoValueTypes<ValueType1, ValueType2, memorySpace>::
+          hadamardProduct(n, x, y, opx, opy, z);
+      }
+
 
       template <typename ValueType1,
                 typename ValueType2,
@@ -182,6 +198,8 @@ namespace dftefe
                      const size_type                      numVec,
                      const ValueType1 *                   multiVecDataX,
                      const ValueType2 *                   multiVecDataY,
+                     const ScalarOp &                     opX,
+                     const ScalarOp &                     opY,
                      scalar_type<ValueType1, ValueType2> *multiVecDotProduct,
                      LinAlgOpContext<memorySpace> &       context)
       {
@@ -191,6 +209,8 @@ namespace dftefe
                          multiVecDataX,
                          multiVecDataY,
                          multiVecDotProduct,
+                         opX,
+                         opY,
                          context);
       }
 

--- a/src/linearAlgebra/BlasLapackKernels.cpp
+++ b/src/linearAlgebra/BlasLapackKernels.cpp
@@ -13,6 +13,7 @@ namespace dftefe
       namespace blasLapackKernelsInternal
       {
         template <typename T>
+        inline
         T
         conjugate(const T &x)
         {
@@ -20,6 +21,7 @@ namespace dftefe
         }
 
         template <>
+        inline
         double
         conjugate(const double &x)
         {
@@ -27,6 +29,7 @@ namespace dftefe
         }
 
         template <>
+        inline
         float
         conjugate(const float &x)
         {

--- a/src/linearAlgebra/BlasLapackKernels.cpp
+++ b/src/linearAlgebra/BlasLapackKernels.cpp
@@ -13,24 +13,21 @@ namespace dftefe
       namespace blasLapackKernelsInternal
       {
         template <typename T>
-        inline
-        T
+        inline T
         conjugate(const T &x)
         {
           return std::conj(x);
         }
 
         template <>
-        inline
-        double
+        inline double
         conjugate(const double &x)
         {
           return x;
         }
 
         template <>
-        inline
-        float
+        inline float
         conjugate(const float &x)
         {
           return x;
@@ -40,8 +37,7 @@ namespace dftefe
         class ScalarProduct
         {
         public:
-          inline
-          static scalar_type<T1, T2>
+          inline static scalar_type<T1, T2>
           prod(T1 t1, T2 t2)
           {
             return ((scalar_type<T1, T2>)t1) * ((scalar_type<T1, T2>)t2);
@@ -52,8 +48,7 @@ namespace dftefe
         class ScalarProduct<T1, T2, ScalarOp::Identity, ScalarOp::Conj>
         {
         public:
-          inline
-          static scalar_type<T1, T2>
+          inline static scalar_type<T1, T2>
           prod(T1 t1, T2 t2)
           {
             return ((scalar_type<T1, T2>)t1) *
@@ -65,8 +60,7 @@ namespace dftefe
         class ScalarProduct<T1, T2, ScalarOp::Conj, ScalarOp::Identity>
         {
         public:
-          inline
-          static scalar_type<T1, T2>
+          inline static scalar_type<T1, T2>
           prod(T1 t1, T2 t2)
           {
             return ((scalar_type<T1, T2>)conjugate(t1)) *
@@ -78,8 +72,7 @@ namespace dftefe
         class ScalarProduct<T1, T2, ScalarOp::Conj, ScalarOp::Conj>
         {
         public:
-          inline
-          static scalar_type<T1, T2>
+          inline static scalar_type<T1, T2>
           prod(T1 t1, T2 t2)
           {
             return ((scalar_type<T1, T2>)conjugate(t1)) *

--- a/src/linearAlgebra/BlasLapackKernels.cpp
+++ b/src/linearAlgebra/BlasLapackKernels.cpp
@@ -10,6 +10,79 @@ namespace dftefe
   {
     namespace blasLapack
     {
+      namespace blasLapackKernelsInternal
+      {
+        template <typename T>
+        T
+        conjugate(const T &x)
+        {
+          return std::conj(x);
+        }
+
+        template <>
+        double
+        conjugate(const double &x)
+        {
+          return x;
+        }
+
+        template <>
+        float
+        conjugate(const float &x)
+        {
+          return x;
+        }
+
+        template <typename T1, typename T2, ScalarOp op1, ScalarOp op2>
+        class ScalarProduct
+        {
+        public:
+          static scalar_type<T1, T2>
+          prod(T1 t1, T2 t2)
+          {
+            return ((scalar_type<T1, T2>)t1) * ((scalar_type<T1, T2>)t2);
+          }
+        };
+
+        template <typename T1, typename T2>
+        class ScalarProduct<T1, T2, ScalarOp::Identity, ScalarOp::Conj>
+        {
+        public:
+          static scalar_type<T1, T2>
+          prod(T1 t1, T2 t2)
+          {
+            return ((scalar_type<T1, T2>)t1) *
+                   ((scalar_type<T1, T2>)conjugate(t2));
+          }
+        };
+
+        template <typename T1, typename T2>
+        class ScalarProduct<T1, T2, ScalarOp::Conj, ScalarOp::Identity>
+        {
+        public:
+          static scalar_type<T1, T2>
+          prod(T1 t1, T2 t2)
+          {
+            return ((scalar_type<T1, T2>)conjugate(t1)) *
+                   ((scalar_type<T1, T2>)t2);
+          }
+        };
+
+        template <typename T1, typename T2>
+        class ScalarProduct<T1, T2, ScalarOp::Conj, ScalarOp::Conj>
+        {
+        public:
+          static scalar_type<T1, T2>
+          prod(T1 t1, T2 t2)
+          {
+            return ((scalar_type<T1, T2>)conjugate(t1)) *
+                   ((scalar_type<T1, T2>)conjugate(t2));
+          }
+        };
+
+
+      } // namespace blasLapackKernelsInternal
+
       template <typename ValueType1,
                 typename ValueType2,
                 dftefe::utils::MemorySpace memorySpace>
@@ -62,6 +135,63 @@ namespace dftefe
           }
       }
 
+      template <typename ValueType1,
+                typename ValueType2,
+                dftefe::utils::MemorySpace memorySpace>
+      void
+      KernelsTwoValueTypes<ValueType1, ValueType2, memorySpace>::
+        hadamardProduct(const size_type                      size,
+                        const ValueType1 *                   x,
+                        const ValueType2 *                   y,
+                        const ScalarOp &                     opx,
+                        const ScalarOp &                     opy,
+                        scalar_type<ValueType1, ValueType2> *z)
+      {
+        if (opx == ScalarOp::Identity && opy == ScalarOp::Identity)
+          {
+            blasLapackKernelsInternal::ScalarProduct<ValueType1,
+                                                     ValueType2,
+                                                     ScalarOp::Identity,
+                                                     ScalarOp::Identity>
+              sp;
+            for (size_type i = 0; i < size; ++i)
+              z[i] = sp.prod(x[i], y[i]);
+          }
+
+        else if (opx == ScalarOp::Identity && opy == ScalarOp::Conj)
+          {
+            blasLapackKernelsInternal::ScalarProduct<ValueType1,
+                                                     ValueType2,
+                                                     ScalarOp::Identity,
+                                                     ScalarOp::Conj>
+              sp;
+            for (size_type i = 0; i < size; ++i)
+              z[i] = sp.prod(x[i], y[i]);
+          }
+
+        else if (opx == ScalarOp::Conj && opy == ScalarOp::Identity)
+          {
+            blasLapackKernelsInternal::ScalarProduct<ValueType1,
+                                                     ValueType2,
+                                                     ScalarOp::Conj,
+                                                     ScalarOp::Identity>
+              sp;
+            for (size_type i = 0; i < size; ++i)
+              z[i] = sp.prod(x[i], y[i]);
+          }
+
+        // opx == ScalarOp::Conj && opy == ScalarOp::Conj
+        else
+          {
+            blasLapackKernelsInternal::ScalarProduct<ValueType1,
+                                                     ValueType2,
+                                                     ScalarOp::Conj,
+                                                     ScalarOp::Conj>
+              sp;
+            for (size_type i = 0; i < size; ++i)
+              z[i] = sp.prod(x[i], y[i]);
+          }
+      }
 
       template <typename ValueType1,
                 typename ValueType2,
@@ -113,16 +243,83 @@ namespace dftefe
         const size_type                      numVec,
         const ValueType1 *                   multiVecDataX,
         const ValueType2 *                   multiVecDataY,
+        const ScalarOp &                     opX,
+        const ScalarOp &                     opY,
         scalar_type<ValueType1, ValueType2> *multiVecDotProduct,
         LinAlgOpContext<memorySpace> &       context)
       {
         std::fill(multiVecDotProduct, multiVecDotProduct + numVec, 0);
-        for (size_type i = 0; i < vecSize; ++i)
-          for (size_type j = 0; j < numVec; ++j)
-            multiVecDotProduct[j] += ((scalar_type<ValueType1, ValueType2>)
-                                        multiVecDataX[i * numVec + j]) *
-                                     ((scalar_type<ValueType1, ValueType2>)
-                                        multiVecDataY[i * numVec + j]);
+        if (opX == ScalarOp::Identity && opY == ScalarOp::Identity)
+          {
+            blasLapackKernelsInternal::ScalarProduct<ValueType1,
+                                                     ValueType2,
+                                                     ScalarOp::Identity,
+                                                     ScalarOp::Identity>
+              sp;
+            for (size_type i = 0; i < vecSize; ++i)
+              {
+                for (size_type j = 0; j < numVec; ++j)
+                  {
+                    multiVecDotProduct[j] +=
+                      sp.prod(multiVecDataX[i * numVec + j],
+                              multiVecDataY[i * numVec + j]);
+                  }
+              }
+          }
+
+        else if (opX == ScalarOp::Identity && opY == ScalarOp::Conj)
+          {
+            blasLapackKernelsInternal::ScalarProduct<ValueType1,
+                                                     ValueType2,
+                                                     ScalarOp::Identity,
+                                                     ScalarOp::Conj>
+              sp;
+            for (size_type i = 0; i < vecSize; ++i)
+              {
+                for (size_type j = 0; j < numVec; ++j)
+                  {
+                    multiVecDotProduct[j] +=
+                      sp.prod(multiVecDataX[i * numVec + j],
+                              multiVecDataY[i * numVec + j]);
+                  }
+              }
+          }
+
+        else if (opX == ScalarOp::Conj && opY == ScalarOp::Identity)
+          {
+            blasLapackKernelsInternal::ScalarProduct<ValueType1,
+                                                     ValueType2,
+                                                     ScalarOp::Conj,
+                                                     ScalarOp::Identity>
+              sp;
+            for (size_type i = 0; i < vecSize; ++i)
+              {
+                for (size_type j = 0; j < numVec; ++j)
+                  {
+                    multiVecDotProduct[j] +=
+                      sp.prod(multiVecDataX[i * numVec + j],
+                              multiVecDataY[i * numVec + j]);
+                  }
+              }
+          }
+
+        if (opX == ScalarOp::Conj && opY == ScalarOp::Conj)
+          {
+            blasLapackKernelsInternal::ScalarProduct<ValueType1,
+                                                     ValueType2,
+                                                     ScalarOp::Conj,
+                                                     ScalarOp::Conj>
+              sp;
+            for (size_type i = 0; i < vecSize; ++i)
+              {
+                for (size_type j = 0; j < numVec; ++j)
+                  {
+                    multiVecDotProduct[j] +=
+                      sp.prod(multiVecDataX[i * numVec + j],
+                              multiVecDataY[i * numVec + j]);
+                  }
+              }
+          }
       }
 
       template <typename ValueType, dftefe::utils::MemorySpace memorySpace>

--- a/src/linearAlgebra/BlasLapackKernels.cpp
+++ b/src/linearAlgebra/BlasLapackKernels.cpp
@@ -37,6 +37,7 @@ namespace dftefe
         class ScalarProduct
         {
         public:
+          inline
           static scalar_type<T1, T2>
           prod(T1 t1, T2 t2)
           {
@@ -48,6 +49,7 @@ namespace dftefe
         class ScalarProduct<T1, T2, ScalarOp::Identity, ScalarOp::Conj>
         {
         public:
+          inline
           static scalar_type<T1, T2>
           prod(T1 t1, T2 t2)
           {
@@ -60,6 +62,7 @@ namespace dftefe
         class ScalarProduct<T1, T2, ScalarOp::Conj, ScalarOp::Identity>
         {
         public:
+          inline
           static scalar_type<T1, T2>
           prod(T1 t1, T2 t2)
           {
@@ -72,6 +75,7 @@ namespace dftefe
         class ScalarProduct<T1, T2, ScalarOp::Conj, ScalarOp::Conj>
         {
         public:
+          inline
           static scalar_type<T1, T2>
           prod(T1 t1, T2 t2)
           {

--- a/src/linearAlgebra/BlasLapackKernels.h
+++ b/src/linearAlgebra/BlasLapackKernels.h
@@ -58,6 +58,13 @@ namespace dftefe
                         const ValueType1 *                   x,
                         const ValueType2 *                   y,
                         scalar_type<ValueType1, ValueType2> *z);
+        static void
+        hadamardProduct(size_type                            size,
+                        const ValueType1 *                   x,
+                        const ValueType2 *                   y,
+                        const ScalarOp &                     opx,
+                        const ScalarOp &                     opy,
+                        scalar_type<ValueType1, ValueType2> *z);
 
         /**
          * @brief Template for performing \f$ {\bf Z}={\bf A} \odot {\bf B} = a_1 \otimes b_1
@@ -105,6 +112,12 @@ namespace dftefe
          * vector index is the fastest index
          * @param[in] multiVecDataY multi vector data in row major format i.e.
          * vector index is the fastest index
+         * @param[in] opX blasLapack::ScalarOp defining the operation on each
+         * entry of multiVecDataX. The available options are
+         * (a) blasLapack::ScalarOp::Identity (identity operation on a scalar),
+         * and (b) blasLapack::ScalarOp::Conj (complex conjugate on a scalar)
+         * @param[in] opY blasLapack::ScalarOp defining the operation on each
+         * entry of multiVecDataY.
          * @param[out] multiVecDotProduct multi vector dot product of size
          * numVec
          *
@@ -114,6 +127,8 @@ namespace dftefe
                        size_type                            numVec,
                        const ValueType1 *                   multiVecDataX,
                        const ValueType2 *                   multiVecDataY,
+                       const ScalarOp &                     opX,
+                       const ScalarOp &                     opY,
                        scalar_type<ValueType1, ValueType2> *multiVecDotProduct,
                        LinAlgOpContext<memorySpace> &       context);
       };
@@ -183,6 +198,14 @@ namespace dftefe
                         const ValueType2 *                   y,
                         scalar_type<ValueType1, ValueType2> *z);
 
+        static void
+        hadamardProduct(size_type                            size,
+                        const ValueType1 *                   x,
+                        const ValueType2 *                   y,
+                        const ScalarOp &                     opx,
+                        const ScalarOp &                     opy,
+                        scalar_type<ValueType1, ValueType2> *z);
+
 
         static void
         khatriRaoProduct(size_type                            sizeI,
@@ -206,6 +229,8 @@ namespace dftefe
           size_type                            numVec,
           const ValueType1 *                   multiVecDataX,
           const ValueType2 *                   multiVecDataY,
+          const ScalarOp &                     opX,
+          const ScalarOp &                     opY,
           scalar_type<ValueType1, ValueType2> *multiVecDotProduct,
           LinAlgOpContext<dftefe::utils::MemorySpace::DEVICE> &context);
       };

--- a/src/linearAlgebra/BlasLapackTypedef.h
+++ b/src/linearAlgebra/BlasLapackTypedef.h
@@ -42,6 +42,12 @@ namespace dftefe
       using Layout = blas::Layout;
       using Queue  = blas::Queue;
 
+      enum class ScalarOp
+      {
+        Identity,
+        Conj
+      };
+
       // real_type< float >                               is float
       // real_type< float, double, complex<float> >       is double
       template <typename ValueType>

--- a/src/utils/DeviceDataTypeOverloads.cuh
+++ b/src/utils/DeviceDataTypeOverloads.cuh
@@ -28,7 +28,49 @@ namespace dftefe
       return cuCabsf(a);
     }
 
-    // mult for homogeneous types e.g. (double, double)
+    //
+    // conjugate overloads
+    //
+
+    __inline__ __device__ size_type
+    conj(size_type a)
+    {
+      return a;
+    }
+
+    __inline__ __device__ int
+    conj(int a)
+    {
+      return a;
+    }
+
+    __inline__ __device__ float
+    conj(float a)
+    {
+      return a;
+    }
+    __inline__ __device__ double
+    conj(double a)
+    {
+      return a;
+    }
+
+    __inline__ __device__ cuDoubleComplex
+    conj(cuDoubleComplex a)
+    {
+      return cuConjf(a);
+    }
+
+    __inline__ __device__ cuFloatComplex
+    conj(cuFloatComplex a)
+    {
+      return cuConjf(a);
+    }
+
+
+    //
+    // mult for real homogeneous types e.g. (double, double)
+    //
     __inline__ __device__ size_type
     mult(size_type a, size_type b)
     {
@@ -53,6 +95,10 @@ namespace dftefe
       return a * b;
     }
 
+    //
+    // mult for complex homogenous types
+    // (e.g., cuDoubleComplex and cuDoubleComplex)
+    //
     __inline__ __device__ cuDoubleComplex
     mult(cuDoubleComplex a, cuDoubleComplex b)
     {
@@ -65,6 +111,11 @@ namespace dftefe
       return cuCmulf(a, b);
     }
 
+
+    //
+    // mult for complex heterogeneous types e.g. (cuDoubleComplex,
+    // cuFloatComplex)
+    //
     __inline__ __device__ cuDoubleComplex
     mult(cuFloatComplex a, cuDoubleComplex b)
     {
@@ -76,6 +127,47 @@ namespace dftefe
     {
       return cuCmul(a, make_cuDoubleComplex(b.x, b.y));
     }
+
+
+    //
+    // mult for real-complex heterogeneous types e.g. (double, cuFloatComplex)
+    //
+    __inline__ __device__ cuDoubleComplex
+    mult(double a, cuDoubleComplex b)
+    {
+      return make_cuDoubleComplex(a * b.x, a * b.y);
+    }
+
+    __inline__ __device__ cuDoubleComplex
+    mult(cuDoubleComplex a, double b)
+    {
+      return make_cuDoubleComplex(b * a.x, b * a.y);
+    }
+
+    __inline__ __device__ cuFloatComplex
+    mult(float a, cuFloatComplex b)
+    {
+      return make_cuFloatComplex(a * b.x, a * b.y);
+    }
+
+    __inline__ __device__ cuFloatComplex
+    mult(cuFloatComplex a, float b)
+    {
+      return make_cuFloatComplex(b * a.x, b * a.y);
+    }
+
+    __inline__ __device__ cuDoubleComplex
+    mult(double a, cuFloatComplex b)
+    {
+      return make_cuDoubleComplex(a * b.x, a * b.y);
+    }
+
+    __inline__ __device__ cuDoubleComplex
+    mult(cuFloatComplex a, double b)
+    {
+      return make_cuDoubleComplex(b * a.x, b * a.y);
+    }
+
 
     __inline__ __device__ size_type
     add(size_type a, size_type b)
@@ -184,43 +276,6 @@ namespace dftefe
     div(cuFloatComplex a, cuFloatComplex b)
     {
       return cuCdivf(a, b);
-    }
-
-    // mult for heterogeneous types e.g. (double, complex)
-    __inline__ __device__ cuDoubleComplex
-    mult(double a, cuDoubleComplex b)
-    {
-      return make_cuDoubleComplex(a * b.x, a * b.y);
-    }
-
-    __inline__ __device__ cuDoubleComplex
-    mult(cuDoubleComplex a, double b)
-    {
-      return make_cuDoubleComplex(b * a.x, b * a.y);
-    }
-
-    __inline__ __device__ cuFloatComplex
-    mult(float a, cuFloatComplex b)
-    {
-      return make_cuFloatComplex(a * b.x, a * b.y);
-    }
-
-    __inline__ __device__ cuFloatComplex
-    mult(cuFloatComplex a, float b)
-    {
-      return make_cuFloatComplex(b * a.x, b * a.y);
-    }
-
-    __inline__ __device__ cuDoubleComplex
-    mult(double a, cuFloatComplex b)
-    {
-      return make_cuDoubleComplex(a * b.x, a * b.y);
-    }
-
-    __inline__ __device__ cuDoubleComplex
-    mult(cuFloatComplex a, double b)
-    {
-      return make_cuDoubleComplex(b * a.x, b * a.y);
     }
 
     inline int *

--- a/src/utils/DeviceDataTypeOverloads.cuh
+++ b/src/utils/DeviceDataTypeOverloads.cuh
@@ -58,7 +58,7 @@ namespace dftefe
     __inline__ __device__ cuDoubleComplex
     conj(cuDoubleComplex a)
     {
-      return cuConjf(a);
+      return cuConj(a);
     }
 
     __inline__ __device__ cuFloatComplex


### PR DESCRIPTION
Modifies the dotMultiVector to handle op(X) \dot op(Y) where op can be pointwise identity or complex-conjugate on X and Y. TO do so, an overload to the hadamardProduct  is added which takes additional opX and opY parameters. Other minor additions involve:
1. conjugate overloads in DeviceDataTypeOverloads.cuh
2. conjugate overloads in BlasLapackKernels.cpp  in local namespace
3. ScalarProduct class template to abstract out the product between two scalars: op1(x)*op2(y) 
 