### PR TITLE
Fix pointer update error in DiscontiguousDataOperations

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -49,7 +49,7 @@ if(ENABLE_MPI)
 
 endif()
 
-target_include_directories(dft-efe-utils PUBLIC ${BOOST_DIR}/include)
+target_include_directories(dft-efe-utils PRIVATE ${BOOST_DIR}/include)
 target_link_directories(dft-efe-utils PUBLIC ${BOOST_DIR}/lib64)
 target_link_directories(dft-efe-utils PUBLIC ${BOOST_DIR}/lib)
 

--- a/src/utils/DiscontiguousDataOperations.cpp
+++ b/src/utils/DiscontiguousDataOperations.cpp
@@ -47,7 +47,7 @@ namespace dftefe
         {
           size_type        index  = *(discontIds + i);
           const ValueType *srcTmp = src + index * nComponents;
-          ValueType *      dstTmp = i * nComponents;
+          ValueType *      dstTmp = dst + i * nComponents;
           memoryTransfer.copy(nComponents, dstTmp, srcTmp)
         }
     }
@@ -65,7 +65,7 @@ namespace dftefe
       for (size_type i = 0; i < N; ++i)
         {
           size_type        index  = *(discontIds + i);
-          const ValueType *srcTmp = i * nComponents;
+          const ValueType *srcTmp = src + i * nComponents;
           ValueType *      dstTmp = dst + index * nComponents;
           memoryTransfer.copy(nComponents, dstTmp, srcTmp)
         }
@@ -83,7 +83,7 @@ namespace dftefe
       for (size_type i = 0; i < N; ++i)
         {
           size_type        index  = *(discontIds + i);
-          const ValueType *srcTmp = i * nComponents;
+          const ValueType *srcTmp = src + i * nComponents;
           ValueType *      dstTmp = dst + index * nComponents;
           for (size_type j = 0; j < nComponents; ++j)
             *(dstTmp + j) += *(srcTmp + j);


### PR DESCRIPTION
There was a pointer update error in DiscontiguousDataOperations.cpp, which is now fixed.